### PR TITLE
Path specific backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.7.0
+## UNRELEASED
 Support for path-specific backends, i.e. backends that only accept traffic for a certain path prefix. This is handy for routing traffic to microservices without subdomains.
 
 ## 1.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.7.0
+Support for path-specific backends, i.e. backends that only accept traffic for a certain path prefix. This is handy for routing traffic to microservices without subdomains.
+
 ## 1.6.1
 Adds previous TLS update across template.
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Note that this can introduce a significant performance overhead, as nginx will n
 
 ### Backends for certain URL paths only
 
-You can configure a backend to respond only to URLs with a certain path prefix. If you do so, traffic for that prefix is sent only to them:
+You can configure a backend exclusively for with a certain path prefix:
 
 ```
 mechanic update mysite --backends=3000,3001:/ci-server
@@ -156,6 +156,8 @@ mechanic update mysite --backends=192.168.1.2:3000,192.168.1.2:4000/ci-server
 ```
 
 The prefix **is included** in the URL passed through to the backend.
+
+If such a backend is present, matching requests are sent only to it. You may have more than one for the same path, in which case they are load balanced by nginx in the usual way.
 
 This feature is useful when microservices share a single hostname.
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,24 @@ mechanic update mysite --https-upstream
 
 Note that this can introduce a significant performance overhead, as nginx will need to validate certificates and encrypt the connection with the backend.
 
+### Backends for certain URL paths only
+
+You can configure a backend to respond only to URLs with a certain path prefix. If you do so, traffic for that prefix is sent only to them:
+
+```
+mechanic update mysite --backends=3000,3001:/ci-server
+```
+
+This is also supported for backends not running on the same computer:
+
+```
+mechanic update mysite --backends=192.168.1.2:3000,192.168.1.2:4000/ci-server
+```
+
+The prefix **is included** in the URL passed through to the backend.
+
+This feature is useful when microservices share a single hostname.
+
 ## Secure sites
 
 Now we've added ecommerce and we need a secure site:

--- a/app.js
+++ b/app.js
@@ -79,9 +79,9 @@ let parsers = {
   },
   addresses: function(s) {
     return _.map(parsers.strings(s), function(s) {
-      let matches = s.match(/^(([^:]+):)?(\d+)(:\/.*)?$/);
+      let matches = s.match(/^(([^:]+):)?(\d+)(\/.*)?$/);
       if (!matches) {
-        throw 'A list of port numbers and/or address:port combinations is expected, separated by commas';
+        throw 'A list of port numbers and/or address:port combinations with optional paths is expected, separated by commas';
       }
       let host, port, path;
       if (matches[2]) {

--- a/app.js
+++ b/app.js
@@ -405,16 +405,18 @@ function reset() {
 }
 
 function pathOf(backend) {
-  const components = backend.split(':');
-  const last = components[components.length - 1];
-  return (last.startsWith('/') && last) || '/';
+  const slashAt = backend.indexOf('/');
+  if (slashAt !== -1) {
+    return backend.substring(slashAt + 1);
+  } else {
+    return '/';
+  }
 }
 
 function withoutPath(backend) {
-  const components = backend.split(':');
-  const last = components[components.length - 1];
-  if (last.startsWith('/')) {
-    return components.slice(0, components.length - 1).join(':');
+  const slashAt = backend.indexOf('/');
+  if (slashAt !== -1) {
+    return backend.substring(0, slashAt);
   } else {
     return backend;
   }

--- a/app.js
+++ b/app.js
@@ -91,7 +91,7 @@ let parsers = {
       }
       port = matches[3];
       path = matches[4];
-      const pathString = (path != null) ? `:${path}` : '';
+      const pathString = (path != null) ? path : '';
       return `${host}:${port}${pathString}`;
     });
   },

--- a/app.js
+++ b/app.js
@@ -330,6 +330,7 @@ function go() {
         site.backendGroups.push(group);
       }
     }
+    return site;
   });
 
   let template = fs.readFileSync(settings.template || (__dirname + '/template.conf'), 'utf8');

--- a/app.js
+++ b/app.js
@@ -79,18 +79,20 @@ let parsers = {
   },
   addresses: function(s) {
     return _.map(parsers.strings(s), function(s) {
-      let matches = s.match(/^(([^:]+):)?(\d+)$/);
+      let matches = s.match(/^(([^:]+):)?(\d+)(:\/.*)?$/);
       if (!matches) {
         throw 'A list of port numbers and/or address:port combinations is expected, separated by commas';
       }
-      let host, port;
+      let host, port, path;
       if (matches[2]) {
         host = matches[2];
       } else {
         host = 'localhost';
       }
       port = matches[3];
-      return host + ':' + port;
+      path = matches[4];
+      const pathString = (path != null) ? `:${path}` : '';
+      return `${host}:${port}${pathString}`;
     });
   },
   strings: function(s) {

--- a/app.js
+++ b/app.js
@@ -323,6 +323,7 @@ function go() {
           path: pathOf(backend),
           backends: [ withoutPath(backend) ]
         };
+        lastPath = pathOf(backend);
       } else {
         group.backends.push(withoutPath(backend));
       }

--- a/app.js
+++ b/app.js
@@ -407,7 +407,7 @@ function reset() {
 function pathOf(backend) {
   const slashAt = backend.indexOf('/');
   if (slashAt !== -1) {
-    return backend.substring(slashAt + 1);
+    return backend.substring(slashAt);
   } else {
     return '/';
   }

--- a/template.conf
+++ b/template.conf
@@ -124,7 +124,7 @@
 {% endmacro %}
 
 {% macro renderSite(site, settings) %}
-  {% for backendGroup in  site.backendGroups %}
+  {% for backendGroup in site.backendGroups %}
     upstream upstream-{{ site.shortname }}-{{ loop.index }} {
       {% for backend in backendGroup.backends -%}
         server {{ backend }};

--- a/template.conf
+++ b/template.conf
@@ -49,11 +49,11 @@
       {% if proxyRoot %}
         location @proxy-{{ site.shortname }}-{{ options.port }} {
           {% if site['https-upstream'] %}
-            proxy_pass https://upstream-{{ site.shortname }}-0;
+            proxy_pass https://upstream-{{ site.shortname }}-1;
             proxy_ssl_session_reuse on;
             proxy_ssl_protocols TLSv1.2 TLSv1.3;
           {% else %}
-            proxy_pass http://upstream-{{ site.shortname }}-0;
+            proxy_pass http://upstream-{{ site.shortname }}-1;
           {% endif %}
 
           {% if site['websockets'] or site['websocket'] %}

--- a/template.conf
+++ b/template.conf
@@ -100,6 +100,10 @@
             {% else %}
               proxy_pass http://upstream-{{ site.shortname }}-{{ loop.index }};
             {% endif %}
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
           }
         {% endif %}
       {% endfor %}

--- a/template.conf
+++ b/template.conf
@@ -43,14 +43,17 @@
       include "{{ settings.overrides }}/{{ site.shortname }}/server";
 
       {# We need a named location block in order to use try_files. #}
-      {% if site.backends.length %}
+
+      {% set defaultBackendGroup = site.backendGroups[0] %}
+      {% set proxyRoot = defaultBackendGroup and (defaultBackendGroup.path == '/') %}
+      {% if proxyRoot %}
         location @proxy-{{ site.shortname }}-{{ options.port }} {
           {% if site['https-upstream'] %}
-            proxy_pass https://upstream-{{ site.shortname }};
+            proxy_pass https://upstream-{{ site.shortname }}-0;
             proxy_ssl_session_reuse on;
             proxy_ssl_protocols TLSv1.2 TLSv1.3;
           {% else %}
-            proxy_pass http://upstream-{{ site.shortname }};
+            proxy_pass http://upstream-{{ site.shortname }}-0;
           {% endif %}
 
           {% if site['websockets'] or site['websocket'] %}
@@ -75,17 +78,31 @@
         {%- if site.static %}root {{ site.static }};{% endif %}
         {% if site.autoindex %}
           autoindex on;
-          {% if site.backends.length %}
+          {% if proxyRoot %}
             try_files $uri $uri/ @proxy-{{ site.shortname }}-{{ options.port }};
           {% endif %}
         {% else %}
-          {% if site.backends.length %}
+          {% if proxyRoot %}
             try_files $uri @proxy-{{ site.shortname }}-{{ options.port }};
           {% endif %}
         {% endif %}
         expires 7d;
         include "{{ settings.overrides }}/{{ site.shortname }}/location";
       }
+
+      {% for backendGroup in site.backendGroups %}
+        {% if backendGroup.path != '/' %}
+          location {{ backendGroup.path }} {
+            {% if site['https-upstream'] %}
+              proxy_pass https://upstream-{{ site.shortname }}-{{ loop.index }};
+              proxy_ssl_session_reuse on;
+              proxy_ssl_protocols TLSv1.2 TLSv1.3;
+            {% else %}
+              proxy_pass http://upstream-{{ site.shortname }}-{{ loop.index }};
+            {% endif %}
+          }
+        {% endif %}
+      {% endfor %}
     {% endif %}
   }
 
@@ -107,9 +124,9 @@
 {% endmacro %}
 
 {% macro renderSite(site, settings) %}
-  {% if site.backends.length %}
-    upstream upstream-{{ site.shortname }} {
-      {% for backend in site.backends -%}
+  {% for backendGroup in  site.backendGroups %}
+    upstream upstream-{{ site.shortname }}-{{ loop.index }} {
+      {% for backend in backendGroup.backends -%}
         server {{ backend }};
       {%- endfor %}
     }

--- a/template.conf
+++ b/template.conf
@@ -130,7 +130,7 @@
         server {{ backend }};
       {%- endfor %}
     }
-  {% endif %}
+  {% endfor %}
 
   {{ server(site, settings, { port: 80 }) }}
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -255,6 +255,47 @@ expect({
   ]
 }, 'Test failed: default site should always wind up at the end of the list');
 
+shelljs.exec('node ../app.js --data=./test.json update defaultsite --backends=localhost:3000,localhost:4000/ci-server');
+
+expect({
+  settings: {
+    conf: './nginx',
+    logs: './logs',
+    restart: 'touch restarted',
+    overrides: './mechanic-overrides',
+    bind: '*'
+  },
+  "sites": [
+    {
+      "shortname": "nondefaultsite",
+      "host": "nondefaultsite.com",
+      "backends": [ 'localhost:3000' ],
+      "backendGroups": [
+        {
+          "path": "/",
+          "backends": [ "localhost:3000" ]
+        }
+      ]
+    },
+    {
+      "shortname": "defaultsite",
+      "host": "defaultsite.com",
+      "default": true,
+      "backends": [ 'localhost:3000', 'localhost:4000/ci-server' ],
+      "backendGroups": [
+        {
+          "path": "/",
+          "backends": [ "localhost:3000" ]
+        },
+        {
+          "path": "/ci-server",
+          "backends": [ "localhost:4000" ]
+        }
+      ]
+    }
+  ]
+}, 'Test failed: ci server backend not listed properly');
+
 if (!fs.existsSync('./mechanic-overrides/mysite/location')) {
   console.error('location override file for mysite does not exist');
   process.exit(1);

--- a/tests/test.js
+++ b/tests/test.js
@@ -32,7 +32,13 @@ expect({
     {
       "shortname": "mysite",
       "host": "mysite.com",
-      "backends": [ 'localhost:3000' ]
+      "backends": [ 'localhost:3000' ],
+      "backendGroups": [
+        {
+          "path": "/",
+          "backends": [ "localhost:3000" ]
+        }
+      ]
     }
   ]
 }, 'Test failed: adding a site should store the right JSON');
@@ -51,7 +57,13 @@ expect({
     {
       "shortname": "mysite",
       "host": "mysite.com",
-      "backends": [ 'localhost:3001' ]
+      "backends": [ 'localhost:3001' ],
+      "backendGroups": [
+        {
+          "path": "/",
+          "backends": [ "localhost:3001" ]
+        }
+      ]
     }
   ]
 }, 'Test failed: alias was not accepted, or update command rejected, or host:port parsed badly');
@@ -83,6 +95,12 @@ expect({
       "shortname": "mysite",
       "host": "mysite.com",
       "backends": [ 'localhost:3000' ],
+      "backendGroups": [
+        {
+          "path": "/",
+          "backends": [ "localhost:3000" ]
+        }
+      ],
       "aliases": [ 'www.mysite.com', 'mysite.temporary.com' ]
     }
   ]
@@ -116,13 +134,25 @@ expect({
       "shortname": "site1",
       "host": "site1.com",
       "backends": [ 'localhost:3000' ],
-      "https": true
+      "https": true,
+      "backendGroups": [
+        {
+          "path": "/",
+          "backends": [ "localhost:3000" ]
+        }
+      ]
     },
     {
       "shortname": "site2",
       "host": "site2.com",
       "backends": [ 'localhost:3001' ],
-      "https": true
+      "https": true,
+      "backendGroups": [
+        {
+          "path": "/",
+          "backends": [ "localhost:3001" ]
+        }
+      ]
     }
   ]
 }, 'Test failed: adding two sites with https should store the right JSON');
@@ -142,13 +172,25 @@ expect({
       "shortname": "site1",
       "host": "site1.com",
       "backends": [ 'localhost:3000' ],
-      "https": true
+      "https": true,
+      "backendGroups": [
+        {
+          "path": "/",
+          "backends": [ "localhost:3000" ]
+        }
+      ]
     },
     {
       "shortname": "site2",
       "host": "site2.com",
       "backends": [ 'localhost:3001' ],
       "https": true,
+      "backendGroups": [
+        {
+          "path": "/",
+          "backends": [ "localhost:3001" ]
+        }
+      ],
       "redirect-to-https": true,
       "websockets": true
     }
@@ -190,13 +232,25 @@ expect({
     {
       "shortname": "nondefaultsite",
       "host": "nondefaultsite.com",
-      "backends": [ 'localhost:3000' ]
+      "backends": [ 'localhost:3000' ],
+      "backendGroups": [
+        {
+          "path": "/",
+          "backends": [ "localhost:3000" ]
+        }
+      ]
     },
     {
       "shortname": "defaultsite",
       "host": "defaultsite.com",
       "default": true,
-      "backends": [ 'localhost:3000' ]
+      "backends": [ 'localhost:3000' ],
+      "backendGroups": [
+        {
+          "path": "/",
+          "backends": [ "localhost:3000" ]
+        }
+      ]
     }
   ]
 }, 'Test failed: default site should always wind up at the end of the list');
@@ -210,6 +264,9 @@ function expect(correct, message) {
   var data = JSON.parse(fs.readFileSync('test.json', 'utf8'));
   if (JSON.stringify(data) !== JSON.stringify(correct)) {
     console.error(message);
+    console.error('EXPECTED:');
+    console.error(JSON.stringify(correct));
+    console.error('ACTUAL:');
     console.error(JSON.stringify(data));
     process.exit(1);
   }


### PR DESCRIPTION
A PR to support backends that receive all the traffic for a particular URL prefix. Useful when microservices share a single host, often but not necessarily with a website catching the rest of the traffic (no path prefix).